### PR TITLE
make ArekConfiguration init() public

### DIFF
--- a/arek/Classes/Core/Utilities/ArekConfiguration.swift
+++ b/arek/Classes/Core/Utilities/ArekConfiguration.swift
@@ -16,7 +16,7 @@ public struct ArekConfiguration {
     private let week = 60.0*60.0*24.0*7.0
     private let hour = 60.0*60.0
     
-    init(frequency: ArekPermissionFrequency, presentInitialPopup: Bool, presentReEnablePopup: Bool) {
+    public init(frequency: ArekPermissionFrequency, presentInitialPopup: Bool, presentReEnablePopup: Bool) {
         self.frequency = frequency
         self.presentInitialPopup = presentInitialPopup
         self.presentReEnablePopup = presentReEnablePopup

--- a/arek/Classes/Core/Utilities/ArekPopupData.swift
+++ b/arek/Classes/Core/Utilities/ArekPopupData.swift
@@ -11,4 +11,8 @@ import Foundation
 public struct ArekPopupData {
     var title: String!
     var message: String!
+    public init(title: String = "", message: String = "") {
+        self.title = title
+        self.message = message
+    }
 }

--- a/arek/Classes/Permissions/ArekPhoto.swift
+++ b/arek/Classes/Permissions/ArekPhoto.swift
@@ -20,8 +20,8 @@ public class ArekPhoto: ArekBasePermission, ArekPermissionProtocol {
         self.reEnablePopupData = ArekPopupData(title: "Photo service", message: "re enable 🙏")
     }
     
-    required public init(configuration: ArekConfiguration, initialPopupData: ArekPopupData?, reEnablePopupData: ArekPopupData?) {
-        super.init(configuration: configuration, initialPopupData: ArekPopupData(), reEnablePopupData: ArekPopupData())
+    required public init(configuration: ArekConfiguration, initialPopupData: ArekPopupData, reEnablePopupData: ArekPopupData) {
+        super.init(configuration: configuration, initialPopupData: initialPopupData, reEnablePopupData: reEnablePopupData)
         super.permission = self
     }
     


### PR DESCRIPTION
Hi there!

Thanks for a nice framework! It seems like it's impossible call the designated initializer of `ArekConfiguration` since the init method isn't marked as public.

This PR makes it possible to create instances of `ArekPhoto` with custom configurations.