### PR TITLE
Added optional ArekPopupStyle parameter

### DIFF
--- a/code/Classes/Core/Arek.swift
+++ b/code/Classes/Core/Arek.swift
@@ -57,8 +57,7 @@ public protocol ArekPermissionProtocol: class {
  Don't instantiate ArekBasePermission directly.
  */
 open class ArekBasePermission {
-    var configuration: ArekConfiguration = ArekConfiguration(frequency: .Always, presentInitialPopup:
-        true, presentReEnablePopup: true)
+    var configuration: ArekConfiguration = ArekConfiguration(frequency: .Always, presentInitialPopup: true, presentReEnablePopup: true)
     var initialPopupData: ArekPopupData = ArekPopupData()
     var reEnablePopupData: ArekPopupData = ArekPopupData()
     
@@ -69,12 +68,15 @@ open class ArekBasePermission {
                                              message: data.initialMessage,
                                              image: data.image,
                                              allowButtonTitle: data.allowButtonTitle,
-                                             denyButtonTitle: data.denyButtonTitle)
+                                             denyButtonTitle: data.denyButtonTitle,
+                                             styling: nil)
+        
         self.reEnablePopupData = ArekPopupData(title: data.reEnableTitle,
                                               message:  data.reEnableMessage,
                                               image: data.image,
                                               allowButtonTitle: data.allowButtonTitle,
-                                              denyButtonTitle: data.denyButtonTitle)
+                                              denyButtonTitle: data.denyButtonTitle,
+                                              styling: nil)
     }
 
     /**
@@ -85,7 +87,10 @@ open class ArekBasePermission {
          - initialPopupData: title and message related to pre-iOS popup
          - reEnablePopupData: title and message related to re-enable permission popup
      */
-    public init(configuration: ArekConfiguration? = nil, initialPopupData: ArekPopupData? = nil, reEnablePopupData: ArekPopupData? = nil) {
+    public init(configuration: ArekConfiguration? = nil,
+                initialPopupData: ArekPopupData? = nil,
+                reEnablePopupData: ArekPopupData? = nil) {
+        
         self.configuration = configuration ?? self.configuration
         self.initialPopupData = initialPopupData ?? self.initialPopupData
         self.reEnablePopupData = reEnablePopupData ?? self.reEnablePopupData
@@ -93,35 +98,107 @@ open class ArekBasePermission {
     
     private func manageInitialPopup(completion: @escaping ArekPermissionResponse) {
         if self.configuration.presentInitialPopup {
-            self.presentInitialPopup(title: self.initialPopupData.title, message: self.initialPopupData.message, image: self.initialPopupData.image, allowButtonTitle: self.initialPopupData.allowButtonTitle, denyButtonTitle: self.initialPopupData.denyButtonTitle, completion: completion)
+            self.presentInitialPopup(title: self.initialPopupData.title,
+                                     message: self.initialPopupData.message,
+                                     image: self.initialPopupData.image,
+                                     allowButtonTitle: self.initialPopupData.allowButtonTitle,
+                                     denyButtonTitle: self.initialPopupData.denyButtonTitle,
+                                     styling: self.initialPopupData.styling,
+                                     completion: completion)
         } else {
             (self as? ArekPermissionProtocol)?.askForPermission(completion: completion)
         }
     }
     
-    private func presentInitialPopup(title: String, message: String, image: String? = nil, allowButtonTitle: String, denyButtonTitle: String, completion: @escaping ArekPermissionResponse) {
+    private func presentInitialPopup(title: String,
+                                     message: String,
+                                     image: String? = nil,
+                                     allowButtonTitle: String,
+                                     denyButtonTitle: String,
+                                     styling: ArekPopupStyle? = nil,
+                                     completion: @escaping ArekPermissionResponse) {
+        
         switch self.initialPopupData.type as ArekPopupType {
         case .codeido:
-            self.presentInitialCodeidoPopup(title: title, message: message, image: image!, allowButtonTitle: allowButtonTitle, denyButtonTitle: denyButtonTitle, completion: completion)
+            self.presentInitialCodeidoPopup(title: title,
+                                            message: message,
+                                            image: image!,
+                                            allowButtonTitle: allowButtonTitle,
+                                            denyButtonTitle: denyButtonTitle,
+                                            styling: styling,
+                                            completion: completion)
             break
         case .native:
-            self.presentInitialNativePopup(title: title, message: message, allowButtonTitle: allowButtonTitle, denyButtonTitle: denyButtonTitle, completion: completion)
+            self.presentInitialNativePopup(title: title,
+                                           message: message,
+                                           allowButtonTitle: allowButtonTitle,
+                                           denyButtonTitle: denyButtonTitle,
+                                           completion: completion)
             break
         }
     }
     
-    private func presentInitialCodeidoPopup(title: String, message: String, image: String, allowButtonTitle: String, denyButtonTitle: String, completion: @escaping ArekPermissionResponse) {
-        let alertVC = PMAlertController(title: title, description: message, image: UIImage(named: image), style: .walkthrough)
+    private func presentInitialCodeidoPopup(title: String,
+                                            message: String,
+                                            image: String,
+                                            allowButtonTitle: String,
+                                            denyButtonTitle: String,
+                                            styling: ArekPopupStyle?,
+                                            completion: @escaping ArekPermissionResponse) {
         
-        alertVC.addAction(PMAlertAction(title: denyButtonTitle, style: .cancel, action: {
+        let alertVC = PMAlertController(title: title,
+                                        description: message,
+                                        image: UIImage(named: image),
+                                        style: .walkthrough)
+        
+        let denyAction = PMAlertAction(title: denyButtonTitle, style: .cancel, action: {
             completion(.denied)
             alertVC.dismiss(animated: true, completion: nil)
-        }))
+        })
         
-        alertVC.addAction(PMAlertAction(title: allowButtonTitle, style: .default, action: {
+        let allowAction = PMAlertAction(title: allowButtonTitle, style: .default, action: {
             (self as? ArekPermissionProtocol)?.askForPermission(completion: completion)
             alertVC.dismiss(animated: true, completion: nil)
-        }))
+        })
+        
+        if let styling = styling {
+            if let cornerRadius = styling.cornerRadius {
+                alertVC.view.layer.cornerRadius = cornerRadius
+            }
+            if let alertMaskBackgroundColor = styling.alertMaskBackgroundColor {
+                alertVC.alertMaskBackground.backgroundColor = alertMaskBackgroundColor
+            }
+            if let alertMaskBackgroundAlpha = styling.alertMaskBackgroundAlpha {
+                alertVC.alertMaskBackground.alpha = alertMaskBackgroundAlpha
+            }
+            if let alertTitleTextColor = styling.alertTitleTextColor {
+                alertVC.alertTitle.textColor = alertTitleTextColor
+            }
+            if let alertTitleFont = styling.alertTitleFont {
+                alertVC.alertTitle.font = alertTitleFont
+            }
+            if let alertDescriptionFont = styling.alertDescriptionFont {
+                alertVC.alertDescription.font = alertDescriptionFont
+            }
+            if let headerViewHeightConstraint = styling.headerViewHeightConstraint {
+                alertVC.headerViewHeightConstraint.constant = headerViewHeightConstraint
+            }
+            if let denyButtonTitleColor = styling.denyButtonTitleColor {
+                denyAction.setTitleColor(denyButtonTitleColor, for: .normal)
+            }
+            if let denyButtonTitleFont = styling.denyButtonTitleFont {
+                denyAction.titleLabel?.font = denyButtonTitleFont
+            }
+            if let allowButtonTitleColor = styling.allowButtonTitleColor {
+                allowAction.setTitleColor(allowButtonTitleColor, for: .normal)
+            }
+            if let allowButtonTitleFont = styling.allowButtonTitleFont {
+                allowAction.titleLabel?.font = allowButtonTitleFont
+            }
+        }
+        
+        alertVC.addAction(denyAction)
+        alertVC.addAction(allowAction)
         
         if var topController = UIApplication.shared.keyWindow?.rootViewController {
             while let presentedViewController = topController.presentedViewController {
@@ -134,7 +211,12 @@ open class ArekBasePermission {
         }
     }
     
-    private func presentInitialNativePopup(title: String, message: String, allowButtonTitle: String, denyButtonTitle: String, completion: @escaping ArekPermissionResponse) {
+    private func presentInitialNativePopup(title: String,
+                                           message: String,
+                                           allowButtonTitle: String,
+                                           denyButtonTitle: String,
+                                           completion: @escaping ArekPermissionResponse) {
+        
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         let allow = UIAlertAction(title: allowButtonTitle, style: .default) { _ in
@@ -165,24 +247,44 @@ open class ArekBasePermission {
         guard let permission = self as? ArekPermissionProtocol else { return }
         
         if self.configuration.canPresentReEnablePopup(permission: permission) {
-            self.presentReEnablePopup(title: self.reEnablePopupData.title, message: self.reEnablePopupData.message, image: self.reEnablePopupData.image, allowButtonTitle: self.reEnablePopupData.allowButtonTitle, denyButtonTitle: self.reEnablePopupData.denyButtonTitle)
+            self.presentReEnablePopup(title: self.reEnablePopupData.title,
+                                      message: self.reEnablePopupData.message,
+                                      image: self.reEnablePopupData.image,
+                                      allowButtonTitle: self.reEnablePopupData.allowButtonTitle,
+                                      denyButtonTitle: self.reEnablePopupData.denyButtonTitle)
         } else {
             print("[🚨 Arek 🚨] for \(self) present re-enable not allowed")
         }
     }
 
-    private func presentReEnablePopup(title: String, message: String, image: String?, allowButtonTitle: String, denyButtonTitle: String) {
+    private func presentReEnablePopup(title: String,
+                                      message: String,
+                                      image: String?,
+                                      allowButtonTitle: String,
+                                      denyButtonTitle: String) {
+        
         switch self.reEnablePopupData.type as ArekPopupType {
         case .codeido:
-            self.presentReEnableCodeidoPopup(title: title, message: message, image: image!, allowButtonTitle: allowButtonTitle, denyButtonTitle: denyButtonTitle)
+            self.presentReEnableCodeidoPopup(title: title,
+                                             message: message,
+                                             image: image!,
+                                             allowButtonTitle: allowButtonTitle,
+                                             denyButtonTitle: denyButtonTitle)
             break
         case .native:
-            self.presentReEnableNativePopup(title: title, message: message, allowButtonTitle: allowButtonTitle, denyButtonTitle: denyButtonTitle)
+            self.presentReEnableNativePopup(title: title,
+                                            message: message,
+                                            allowButtonTitle: allowButtonTitle,
+                                            denyButtonTitle: denyButtonTitle)
             break
         }
     }
     
-    private func presentReEnableNativePopup(title: String, message: String, allowButtonTitle: String, denyButtonTitle: String) {
+    private func presentReEnableNativePopup(title: String,
+                                            message: String,
+                                            allowButtonTitle: String,
+                                            denyButtonTitle: String) {
+        
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         let allow = UIAlertAction(title: allowButtonTitle, style: .default) { _ in
@@ -214,7 +316,12 @@ open class ArekBasePermission {
 
     }
     
-    private func presentReEnableCodeidoPopup(title: String, message: String, image: String, allowButtonTitle: String, denyButtonTitle: String) {
+    private func presentReEnableCodeidoPopup(title: String,
+                                             message: String,
+                                             image: String,
+                                             allowButtonTitle: String,
+                                             denyButtonTitle: String) {
+        
         let alertVC = PMAlertController(title: title, description: message, image: UIImage(named: image), style: .walkthrough)
         
         alertVC.addAction(PMAlertAction(title: denyButtonTitle, style: .cancel, action: {

--- a/code/Classes/Core/Utilities/ArekPopupData.swift
+++ b/code/Classes/Core/Utilities/ArekPopupData.swift
@@ -37,13 +37,22 @@ public struct ArekPopupData {
     var allowButtonTitle: String!
     var denyButtonTitle: String!
     var type: ArekPopupType!
+    var styling: ArekPopupStyle?
 
-    public init(title: String = "", message: String = "", image: String = "", allowButtonTitle: String = "", denyButtonTitle: String = "", type: ArekPopupType = .codeido) {
+    public init(title: String = "",
+                message: String = "",
+                image: String = "",
+                allowButtonTitle: String = "",
+                denyButtonTitle: String = "",
+                type: ArekPopupType = .codeido,
+                styling: ArekPopupStyle? = nil) {
+        
         self.title = title
         self.message = message
         self.image = image
         self.allowButtonTitle = allowButtonTitle
         self.denyButtonTitle = denyButtonTitle
         self.type = type
+        self.styling = styling
     }
 }

--- a/code/Classes/Core/Utilities/ArekPopupStyle.swift
+++ b/code/Classes/Core/Utilities/ArekPopupStyle.swift
@@ -1,0 +1,70 @@
+//
+//  ArekPopupStyle.swift
+//  Arek
+//
+//  Copyright (c) 2018 Aleksandr Pasevin
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public struct ArekPopupStyle {
+    var cornerRadius: CGFloat?
+    var alertMaskBackgroundColor: UIColor?
+    var alertMaskBackgroundAlpha: CGFloat?
+    var alertTitleTextColor: UIColor?
+    var alertTitleFont: UIFont?
+    var alertDescriptionFont: UIFont?
+    var headerViewHeightConstraint: CGFloat?
+    
+    var allowButtonTitleColor: UIColor?
+    var allowButtonTitleFont: UIFont?
+    
+    var denyButtonTitleColor: UIColor?
+    var denyButtonTitleFont: UIFont?
+
+    public init(cornerRadius: CGFloat? = nil,
+                alertMaskBackgroundColor: UIColor? = nil,
+                alertMaskBackgroundAlpha: CGFloat? = nil,
+                alertTitleTextColor: UIColor? = nil,
+                alertTitleFont: UIFont? = nil,
+                alertDescriptionFont: UIFont? = nil,
+                headerViewHeightConstraint: CGFloat? = nil,
+                allowButtonTitleColor: UIColor? = nil,
+                allowButtonTitleFont: UIFont? = nil,
+                denyButtonTitleColor: UIColor? = nil,
+                denyButtonTitleFont: UIFont? = nil) {
+        
+        self.cornerRadius = cornerRadius
+        self.alertMaskBackgroundColor = alertMaskBackgroundColor
+        self.alertMaskBackgroundAlpha = alertMaskBackgroundAlpha
+        self.alertTitleTextColor = alertTitleTextColor
+        self.alertTitleFont = alertTitleFont
+        self.alertDescriptionFont = alertDescriptionFont
+        self.headerViewHeightConstraint = headerViewHeightConstraint
+        
+        self.allowButtonTitleColor = allowButtonTitleColor
+        self.allowButtonTitleFont = allowButtonTitleFont
+        
+        self.denyButtonTitleColor = denyButtonTitleColor
+        self.denyButtonTitleFont = denyButtonTitleFont
+
+    }
+}


### PR DESCRIPTION
It allows to manipulate PMAlertController visual aspects such as:

- cornerRadius
- alertMaskBackground (color/alpha)
- alertTitleText (color/font)
- alertDescriptionText (color/font)
- headerViewHeight (to adjust image size)
- deny/allow buttons (color/font)

If ArekPopupStyle is not passed, then defaults of PMAlertController are used.