### PR TITLE
Added padding options supported by PMAlertController

### DIFF
--- a/Example/arek_example/ArekCellVMServiceProgrammatically.swift
+++ b/Example/arek_example/ArekCellVMServiceProgrammatically.swift
@@ -42,7 +42,33 @@ class ArekCellVMServiceProgrammatically {
         let data = permissions[index]
         
         let configuration = ArekConfiguration(frequency: .Always, presentInitialPopup: true, presentReEnablePopup: true)
-        let initialPopupData = ArekPopupData(title: data["popupDataTitle"]!, message: data["enableTitle"]!, image: "", allowButtonTitle: data["allowButtonTitle"]!, denyButtonTitle: data["denyButtonTitle"]!, type: getPopupType(index: index), styling: ArekPopupStyle(cornerRadius: 0.9, maskBackgroundColor: UIColor.orange, maskBackgroundAlpha: 1.0, titleTextColor: UIColor.green, titleFont: nil, descriptionFont: nil, descriptionLineHeight: nil, headerViewHeightConstraint: nil, allowButtonTitleColor: nil, allowButtonTitleFont: nil, denyButtonTitleColor: UIColor.brown, denyButtonTitleFont: nil))
+        let initialPopupData = ArekPopupData(title: data["popupDataTitle"]!,
+                                             message: data["enableTitle"]!,
+                                             image: "",
+                                             allowButtonTitle: data["allowButtonTitle"]!,
+                                             denyButtonTitle: data["denyButtonTitle"]!,
+                                             type: getPopupType(index: index),
+                                             styling: ArekPopupStyle(cornerRadius: 0.9,
+                                                                     maskBackgroundColor: UIColor.orange,
+                                                                     maskBackgroundAlpha: 1.0,
+                                                                     titleTextColor: UIColor.green,
+                                                                     titleFont: nil,
+                                                                     descriptionFont: nil,
+                                                                     descriptionLineHeight: nil,
+                                                                     headerViewHeightConstraint: nil,
+                                                                     allowButtonTitleColor: nil,
+                                                                     allowButtonTitleFont: nil,
+                                                                     denyButtonTitleColor: UIColor.brown,
+                                                                     denyButtonTitleFont: nil,
+                                                                     headerViewTopSpace: 20,
+                                                                     descriptionLeftSpace: 20,
+                                                                     descriptionRightSpace: 20,
+                                                                     descriptionTopSpace: 20,
+                                                                     buttonsLeftSpace: 0,
+                                                                     buttonsRightSpace: 0,
+                                                                     buttonsTopSpace: 20,
+                                                                     buttonsBottomSpace: 0))
+        
         let reenablePopupData = ArekPopupData(title: data["popupDataTitle"]!, message: data["reEnableTitle"]!, image: "", allowButtonTitle: data["allowButtonTitle"]!, denyButtonTitle: data["denyButtonTitle"]!, type: getPopupType(index: index), styling: nil)
         
         let permission = getPermissionType(index: index, configuration: configuration, initialPopupData: initialPopupData, reEnablePopupData: reenablePopupData)

--- a/arek.podspec
+++ b/arek.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.swift_version    = '4.0'
   s.source_files = 'code/Classes/**/*', 'code/Classes/Core/**/*', 'code/Classes/Permissions/**/*'
   s.exclude_files = 'Example/*'
-  s.dependency 'PMAlertController', '3.2.0'
+  s.dependency 'PMAlertController', '3.4.0'
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'code/Classes/Core/**/*.swift'

--- a/code/Classes/Core/Arek.swift
+++ b/code/Classes/Core/Arek.swift
@@ -202,6 +202,30 @@ open class ArekBasePermission {
             if let allowButtonTitleFont = styling.allowButtonTitleFont {
                 allowAction.titleLabel?.font = allowButtonTitleFont
             }
+            if let headerViewTopSpace = styling.headerViewTopSpace {
+                alertVC.headerViewTopSpaceConstraint.constant = headerViewTopSpace
+            }
+            if let alertDescriptionLeftSpace = styling.alertDescriptionLeftSpace {
+                alertVC.alertContentStackViewLeadingConstraint.constant = alertDescriptionLeftSpace
+            }
+            if let alertDescriptionRightSpace = styling.alertDescriptionRightSpace {
+                alertVC.alertContentStackViewTrailingConstraint.constant = alertDescriptionRightSpace
+            }
+            if let alertDescriptionTopSpace = styling.alertDescriptionTopSpace {
+                alertVC.alertContentStackViewTopConstraint.constant = alertDescriptionTopSpace
+            }
+            if let alertButtonsLeftSpace = styling.alertButtonsLeftSpace {
+                alertVC.alertActionStackViewLeadingConstraint.constant = alertButtonsLeftSpace
+            }
+            if let alertButtonsRightSpace = styling.alertButtonsRightSpace {
+                alertVC.alertActionStackViewTrailingConstraint.constant = alertButtonsRightSpace
+            }
+            if let alertButtonsTopSpace = styling.alertButtonsTopSpace {
+                alertVC.alertActionStackViewTopConstraint.constant = alertButtonsTopSpace
+            }
+            if let alertButtonsBottomSpace = styling.alertButtonsBottomSpace {
+                alertVC.alertActionStackViewBottomConstraint.constant = alertButtonsBottomSpace
+            }
         }
         
         alertVC.addAction(denyAction)

--- a/code/Classes/Core/Utilities/ArekPopupStyle.swift
+++ b/code/Classes/Core/Utilities/ArekPopupStyle.swift
@@ -40,6 +40,16 @@ public struct ArekPopupStyle {
     
     var denyButtonTitleColor: UIColor?
     var denyButtonTitleFont: UIFont?
+    
+    // Paddings
+    var headerViewTopSpace: CGFloat?
+    var alertDescriptionLeftSpace: CGFloat?
+    var alertDescriptionRightSpace: CGFloat?
+    var alertDescriptionTopSpace: CGFloat?
+    var alertButtonsLeftSpace: CGFloat?
+    var alertButtonsRightSpace: CGFloat?
+    var alertButtonsTopSpace: CGFloat?
+    var alertButtonsBottomSpace: CGFloat?
 
     public init(cornerRadius: CGFloat? = nil,
                 alertMaskBackgroundColor: UIColor? = nil,
@@ -52,7 +62,15 @@ public struct ArekPopupStyle {
                 allowButtonTitleColor: UIColor? = nil,
                 allowButtonTitleFont: UIFont? = nil,
                 denyButtonTitleColor: UIColor? = nil,
-                denyButtonTitleFont: UIFont? = nil) {
+                denyButtonTitleFont: UIFont? = nil,
+                headerViewTopSpace: CGFloat? = nil,
+                alertDescriptionLeftSpace: CGFloat? = nil,
+                alertDescriptionRightSpace: CGFloat? = nil,
+                alertDescriptionTopSpace: CGFloat? = nil,
+                alertButtonsLeftSpace: CGFloat? = nil,
+                alertButtonsRightSpace: CGFloat? = nil,
+                alertButtonsTopSpace: CGFloat? = nil,
+                alertButtonsBottomSpace: CGFloat? = nil) {
         
         self.cornerRadius = cornerRadius
         self.alertMaskBackgroundColor = alertMaskBackgroundColor
@@ -68,6 +86,15 @@ public struct ArekPopupStyle {
         
         self.denyButtonTitleColor = denyButtonTitleColor
         self.denyButtonTitleFont = denyButtonTitleFont
+        
+        self.headerViewTopSpace = headerViewTopSpace
+        self.alertDescriptionLeftSpace = alertDescriptionLeftSpace
+        self.alertDescriptionRightSpace = alertDescriptionRightSpace
+        self.alertDescriptionTopSpace = alertDescriptionTopSpace
+        self.alertButtonsLeftSpace = alertButtonsLeftSpace
+        self.alertButtonsRightSpace = alertButtonsRightSpace
+        self.alertButtonsTopSpace = alertButtonsTopSpace
+        self.alertButtonsBottomSpace = alertButtonsBottomSpace
 
     }
 }


### PR DESCRIPTION
As I mentioned in my previous PR https://github.com/ennioma/arek/pull/110 my PR https://github.com/pmusolino/PMAlertController/pull/61 here got merged and now we can adjust paddings if we want to.

Supported optional options:

- headerViewTopSpace
- descriptionLeftSpace
- descriptionRightSpace
- descriptionTopSpace
- buttonsLeftSpace
- buttonsRightSpace
- buttonsTopSpace
- buttonsBottomSpace

Example:

```
 let popupStyle = ArekPopupStyle(cornerRadius: 12,
                                 maskBackgroundColor: UIColor.black,
                                 maskBackgroundAlpha: 0,
                                 titleTextColor: UIColor.hypeBlackColor(),
                                 titleFont: UIFont(name: "HelveticaNeue-CondensedBold", size: 18.0),
                                 descriptionFont: UIFont(name: "HelveticaNeue", size: 13.0),
                                 descriptionLineHeight: 6.0,
                                 headerViewHeightConstraint: 60.0,
                                 allowButtonTitleColor: UIColor.hypeGreenColor(),
                                 allowButtonTitleFont: UIFont(name: "HelveticaNeue-CondensedBold", size: 18.0),
                                 denyButtonTitleColor: UIColor.hypeRedColor(),
                                 denyButtonTitleFont: UIFont(name: "HelveticaNeue-CondensedBold", size: 18.0),
                                 headerViewTopSpace: 20,
                                 descriptionLeftSpace: 20,
                                 descriptionRightSpace: 20,
                                 descriptionTopSpace: 20,
                                 buttonsLeftSpace: 0,
                                 buttonsRightSpace: 0,
                                 buttonsTopSpace: 20,
                                 buttonsBottomSpace: 0)
```