### PR TITLE
Allow compiling on Xcode 10

### DIFF
--- a/code/Classes/Permissions/ArekNotifications.swift
+++ b/code/Classes/Permissions/ArekNotifications.swift
@@ -49,6 +49,8 @@ open class ArekNotifications: ArekBasePermission, ArekPermissionProtocol {
                     return completion(.denied)
                 case .authorized:
                     return completion(.authorized)
+                case .provisional:
+                  break
                 }
             }
         } else if #available(iOS 9.0, *) {

--- a/code/Classes/Permissions/ArekNotifications.swift
+++ b/code/Classes/Permissions/ArekNotifications.swift
@@ -49,7 +49,7 @@ open class ArekNotifications: ArekBasePermission, ArekPermissionProtocol {
                     return completion(.denied)
                 case .authorized:
                     return completion(.authorized)
-                case .provisional:
+                default:
                   break
                 }
             }


### PR DESCRIPTION
After upgrading to Xcode 10, I was unable to compile my project due to a missing switch case for a new case called `provisional`.  Not sure how you want to handle it, but I'd at least like to unblock my project from getting compiled.